### PR TITLE
feat: dynamically add styles for pass fail status

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,83 +85,9 @@
                       <span class="level">AA+</span>
                       <span class="level">AAA+</span>
                     </div>
-                    <div class="checks">
-                      <div class="pass">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          xmlns:xlink="http://www.w3.org/1999/xlink"
-                          width="15px"
-                          height="100%"
-                          viewBox="0 -4 30 30"
-                          version="1.1"
-                        >
-                          <defs>
-                            <linearGradient
-                              x1="50%"
-                              y1="0%"
-                              x2="50%"
-                              y2="100%"
-                              id="linearGradient-1"
-                            >
-                              <stop stop-color="#1DD47F" offset="0%" />
-                              <stop stop-color="#0DA949" offset="100%" />
-                            </linearGradient>
-                          </defs>
-                          <g
-                            stroke="none"
-                            stroke-width="1"
-                            fill="none"
-                            fill-rule="evenodd"
-                          >
-                            <g
-                              id="ui-gambling-website-lined-icnos-casinoshunter"
-                              transform="translate(-735.000000, -1911.000000)"
-                              fill="url(#linearGradient-1)"
-                              fill-rule="nonzero"
-                            >
-                              <g transform="translate(50.000000, 1871.000000)">
-                                <path
-                                  d="M714.442949,40.6265241 C715.185684,41.4224314 715.185684,42.6860985 714.442949,43.4820059 L697.746773,61.3734759 C697.314529,61.8366655 696.704235,62.0580167 696.097259,61.9870953 C695.539848,62.0082805 694.995328,61.7852625 694.600813,61.3625035 L685.557051,51.6712906 C684.814316,50.8753832 684.814316,49.6117161 685.557051,48.8158087 C686.336607,47.9804433 687.631056,47.9804433 688.410591,48.8157854 L696.178719,57.1395081 L711.589388,40.6265241 C712.368944,39.7911586 713.663393,39.7911586 714.442949,40.6265241 Z"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                        </svg>
-                      </div>
-                      <div class="pass">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          xmlns:xlink="http://www.w3.org/1999/xlink"
-                          width="15px"
-                          height="100%"
-                          viewBox="0 -4 30 30"
-                        >
-                          <defs>
-                            <linearGradient x1="50%" y1="0%" x2="50%" y2="100%">
-                              <stop stop-color="#1DD47F" offset="0%" />
-                              <stop stop-color="#0DA949" offset="100%" />
-                            </linearGradient>
-                          </defs>
-                          <g
-                            stroke="none"
-                            stroke-width="1"
-                            fill="none"
-                            fill-rule="evenodd"
-                          >
-                            <g
-                              transform="translate(-735.000000, -1911.000000)"
-                              fill="url(#linearGradient-1)"
-                              fill-rule="nonzero"
-                            >
-                              <g transform="translate(50.000000, 1871.000000)">
-                                <path
-                                  d="M714.442949,40.6265241 C715.185684,41.4224314 715.185684,42.6860985 714.442949,43.4820059 L697.746773,61.3734759 C697.314529,61.8366655 696.704235,62.0580167 696.097259,61.9870953 C695.539848,62.0082805 694.995328,61.7852625 694.600813,61.3625035 L685.557051,51.6712906 C684.814316,50.8753832 684.814316,49.6117161 685.557051,48.8158087 C686.336607,47.9804433 687.631056,47.9804433 688.410591,48.8157854 L696.178719,57.1395081 L711.589388,40.6265241 C712.368944,39.7911586 713.663393,39.7911586 714.442949,40.6265241 Z"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                        </svg>
-                      </div>
+                    <div class="checks-container">
+                      <span class="checks AA-small"></span>
+                      <span class="checks AAA-small"></span>
                     </div>
                   </div>
                 </div>
@@ -172,40 +98,9 @@
                       <span class="level">AA+</span>
                       <span class="level">AAA+</span>
                     </div>
-                    <div class="checks">
-                      <div class="fail">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          xmlns:xlink="http://www.w3.org/1999/xlink"
-                          version="1.1"
-                          width="15px"
-                          height="100%"
-                          viewBox="0 0 511.999 511.999"
-                          style="enable-background: new 0 0 511.999 511.999"
-                          xml:space="preserve"
-                        >
-                          <path
-                            style="fill: #ff6465"
-                            d="M384.955,256l120.28-120.28c9.019-9.019,9.019-23.642,0-32.66L408.94,6.765  c-9.019-9.019-23.642-9.019-32.66,0l-120.28,120.28L135.718,6.765c-9.019-9.019-23.642-9.019-32.66,0L6.764,103.058  c-9.019,9.019-9.019,23.642,0,32.66l120.28,120.28L6.764,376.28c-9.019,9.019-9.019,23.642,0,32.66l96.295,96.294  c9.019,9.019,23.642,9.019,32.66,0l120.28-120.28l120.28,120.28c9.019,9.019,23.642,9.019,32.66,0l96.295-96.294  c9.019-9.019,9.019-23.642,0-32.66L384.955,256z"
-                          />
-                        </svg>
-                      </div>
-                      <div class="fail">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          xmlns:xlink="http://www.w3.org/1999/xlink"
-                          width="15px"
-                          height="100%"
-                          viewBox="0 0 511.999 511.999"
-                          style="enable-background: new 0 0 511.999 511.999"
-                          xml:space="preserve"
-                        >
-                          <path
-                            style="fill: #ff6465"
-                            d="M384.955,256l120.28-120.28c9.019-9.019,9.019-23.642,0-32.66L408.94,6.765  c-9.019-9.019-23.642-9.019-32.66,0l-120.28,120.28L135.718,6.765c-9.019-9.019-23.642-9.019-32.66,0L6.764,103.058  c-9.019,9.019-9.019,23.642,0,32.66l120.28,120.28L6.764,376.28c-9.019,9.019-9.019,23.642,0,32.66l96.295,96.294  c9.019,9.019,23.642,9.019,32.66,0l120.28-120.28l120.28,120.28c9.019,9.019,23.642,9.019,32.66,0l96.295-96.294  c9.019-9.019,9.019-23.642,0-32.66L384.955,256z"
-                          />
-                        </svg>
-                      </div>
+                    <div class="checks-container">
+                      <span class="checks AA-large"></span>
+                      <span class="checks AAA-large"></span>
                     </div>
                   </div>
                 </div>

--- a/index.js
+++ b/index.js
@@ -188,6 +188,43 @@ const displayChecks = () => {
     resetCheck(graphicsAA);
   }
 };
+const setTextStatus = (element, className, text) => {
+  element.classList.add(className);
+  element.innerText = text
+};
+const handleTextStatus = () => {
+  let contrastScore = ratioResult.innerText
+  let checkIcon = document.querySelectorAll(".checks")
+  if(contrastScore == 0) {
+    checkIcon.forEach(item => resetCheck(item))
+  }else{
+  if(contrastScore >= 3 && contrastScore < 4.5) {
+    checkIcon.forEach(item => {
+        if(item.classList.contains("AA-large")) {
+          setTextStatus(item,"pass", "Pass");
+        }else {
+          setTextStatus(item,"fail", "Fail");
+        }
+      });
+    }else if(contrastScore >= 4.5 && contrastScore < 7) {
+      checkIcon.forEach(x => {
+      if(item.classList.contains("AAA-small")) {
+        setTextStatus(item,"fail", "Fail");
+      }else {
+        setTextStatus(item,"pass", "Pass");
+      }
+    })
+    }else if(contrastScore >= 7) {
+      checkIcon.forEach(item => {
+      setTextStatus(item,"pass", "Pass");
+    });
+    }else {
+      checkIcon.forEach(item => {
+        setTextStatus(item,"fail", "Fail");
+      });
+    }
+  }
+};
 
 const displayRatioResult = () => {
   let firstColor = foregroundColor.value;
@@ -254,11 +291,13 @@ const handleChange = () => {
   clearErrors();
   displayColor();
   resetCheck(graphicsAA);
+  handleTextStatus()
 };
 
 const displayResult = () => {
   displayRatioResult();
   displayChecks();
+  handleTextStatus()
 };
 
 foregroundColor.oninput = handleChange;

--- a/index.js
+++ b/index.js
@@ -198,33 +198,23 @@ const handleTextStatus = () => {
   if(contrastScore == 0) {
     checkIcon.forEach(item => resetCheck(item))
   }else{
-  if(contrastScore >= 3 && contrastScore < 4.5) {
     checkIcon.forEach(item => {
-        if(item.classList.contains("AA-large")) {
-          setTextStatus(item,"pass", "Pass");
-        }else {
+      if(contrastScore >= 3 && contrastScore < 4.5) {
+        item.classList.contains("AA-large") ?
+          setTextStatus(item,"pass", "Pass"): 
           setTextStatus(item,"fail", "Fail");
-        }
-      });
-    }else if(contrastScore >= 4.5 && contrastScore < 7) {
-      checkIcon.forEach(item => {
-      if(item.classList.contains("AAA-small")) {
-        setTextStatus(item,"fail", "Fail");
-      }else {
+        }else if(contrastScore >= 4.5 && contrastScore < 7) {
+        item.classList.contains("AAA-small") ?
+          setTextStatus(item,"fail", "Fail"):
+          setTextStatus(item,"pass", "Pass");
+        }else if(contrastScore >= 7){
         setTextStatus(item,"pass", "Pass");
-      }
-    })
-    }else if(contrastScore >= 7) {
-      checkIcon.forEach(item => {
-      setTextStatus(item,"pass", "Pass");
-    });
-    }else {
-      checkIcon.forEach(item => {
+      }else {
         setTextStatus(item,"fail", "Fail");
+      };   
       });
-    }
-  }
-};
+    };
+  };
 
 const displayRatioResult = () => {
   let firstColor = foregroundColor.value;

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ const handleTextStatus = () => {
         }
       });
     }else if(contrastScore >= 4.5 && contrastScore < 7) {
-      checkIcon.forEach(x => {
+      checkIcon.forEach(item => {
       if(item.classList.contains("AAA-small")) {
         setTextStatus(item,"fail", "Fail");
       }else {

--- a/styles.css
+++ b/styles.css
@@ -333,4 +333,13 @@ small {
     flex-direction: row;
     align-items: flex-start;
   } 
-};
+  .checks-container {
+    display: flex;
+  }
+}
+
+@media(max-width: 768px) {
+  .checks-container {
+    display: flex;
+  }
+}


### PR DESCRIPTION
# Description
The `svg` icons where removed and replaced with `span` tags,  a `handleTextStatus` and `setTextStatus` function were added to change style for pass fail status.
<!-- Please include a detailed summary of the changes made. Also please link the issue that this PR is fixing. -->

Fixes #126 

<!-- Please place an x in the [ ] to check off the type of change for this PR -->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!-- Please make sure to go through the entire checklist before requesting a review. Place an x in the [ ] to check off all of the items completed -->

## Checklist

- [x] I have a descriptive title for my PR
- [x] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] I have run the project locally and reviewed the code changes
- [x] My changes generate no new warnings
